### PR TITLE
Fix error message when 'clientic.png' is not available

### DIFF
--- a/src/import/Import_KeePassX_Xml.cpp
+++ b/src/import/Import_KeePassX_Xml.cpp
@@ -45,7 +45,7 @@ bool Import_KeePassX_Xml::importDatabase(QWidget* Parent, IDatabase* database){
 	QStringList GroupNames;
 	for(int i=0;i<TopLevelGroupNodes.count();i++){
 		if(TopLevelGroupNodes.at(i).toElement().tagName()!="group"){
-			qWarning("Import_KeePassX_Xml: Error: Unknow tag '%s'",CSTR(TopLevelGroupNodes.at(i).toElement().tagName()));
+			qWarning("Import_KeePassX_Xml: Error: Unknown tag '%s'",CSTR(TopLevelGroupNodes.at(i).toElement().tagName()));
 			QMessageBox::critical(GuiParent,tr("Import Failed"),tr("Parsing error: File is no valid KeePassX XML file."));		
 			return false;
 		}

--- a/src/lib/tools.cpp
+++ b/src/lib/tools.cpp
@@ -146,7 +146,7 @@ QString getImageFile(const QString& name){
 	else{
 		QString errMsg = QApplication::translate("Main","File '%1' could not be found.").arg(name);
 		showErrMsg(errMsg);
-		qFatal("File '%s' could not be found.", CSTR(errMsg));
+		qFatal("Error: '%s'", CSTR(errMsg));
 		return QString();
 	}
 }


### PR DESCRIPTION
Currently, when `clientic.png` is not available, KeePassZ prints out a duplicate error message:

``` bash
$ ./src/keepassz 
File 'File 'clientic.png' could not be found.' could not be found.
Aborted
```

This alters the string so it matches the output shown in the UI popup:

``` bash
$ ./src/keepassz 
Error: 'File 'clientic.png' could not be found.'
Aborted
```

The error can be easily reproduced; create a clean git clone, `mkdir build && cd build && cmake .. && make` and attempt to run the created `keepassz` binary, it will print out the error message to the terminal.

The other commit is just a typo fix I noticed on the way. Hope you're having a great day! :)
